### PR TITLE
Add User to Profile table 

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,3 @@
 class Profile < ApplicationRecord
-  # belongs_to :user
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   include Authentication
   has_many :examples
+  has_one :profile
+  # has_many :posts
 end

--- a/db/migrate/20171130200544_add_user_to_profile.rb
+++ b/db/migrate/20171130200544_add_user_to_profile.rb
@@ -1,0 +1,5 @@
+class AddUserToProfile < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :profiles, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171130022954) do
+ActiveRecord::Schema.define(version: 20171130200544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 20171130022954) do
     t.string "handle"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -49,4 +51,5 @@ ActiveRecord::Schema.define(version: 20171130022954) do
   end
 
   add_foreign_key "examples", "users"
+  add_foreign_key "profiles", "users"
 end


### PR DESCRIPTION
- Create relationship by generating migration
`rails g migration AddUserToProfile user:references`
- Use `bundle exec rake db:migrate` to run migration 
- Add `belongs_to :user` relationship in Profile model
 - Add `has_one :profile` relationship in User model 
- Test relationship by creating new users in console
`User.create(email:”string”, password:”string”)` 
`Profile.create(quote:”string”, handle:”string”, user_id:integer)`